### PR TITLE
Show API server username in upload message

### DIFF
--- a/mRemoteNG/Language/Language.resx
+++ b/mRemoteNG/Language/Language.resx
@@ -1806,7 +1806,7 @@ mRemoteNG will now quit and begin with the installation.</value>
     <value>Upload</value>
   </data>
   <data name="ApiServerDetailsMessage" xml:space="preserve">
-    <value>API Server URL: {0}&#x0d;&#x0a;API Server Password: {1}</value>
+    <value>API Server URL: {0}&#x0d;&#x0a;API Server Username: {1}&#x0d;&#x0a;API Server Password: {2}</value>
   </data>
   <data name="PropertyDescriptionRDPMinutesToIdleTimeout" xml:space="preserve">
     <value>The number of minutes for the RDP session to sit idle before automatically disconnecting (for no limit use 0)</value>

--- a/mRemoteNG/UI/Window/ConnectionTreeWindow.cs
+++ b/mRemoteNG/UI/Window/ConnectionTreeWindow.cs
@@ -15,6 +15,7 @@ using mRemoteNG.Tree.ClickHandlers;
 using mRemoteNG.Tree.Root;
 using mRemoteNG.UI.Controls.ConnectionTree;
 using mRemoteNG.UI.TaskDialog;
+using mRemoteNG.Security.SymmetricEncryption;
 using WeifenLuo.WinFormsUI.Docking;
 using mRemoteNG.Resources.Language;
 using System.Runtime.Versioning;
@@ -271,10 +272,14 @@ namespace mRemoteNG.UI.Window
 
         private void ShowApiServerCredentialsMessage()
         {
-            string apiServerUrl = Settings.Default.ApiServerUrl ?? string.Empty;
-            string apiServerPassword = Settings.Default.ApiServerPassword ?? string.Empty;
+            LegacyRijndaelCryptographyProvider cryptographyProvider = new();
 
-            string message = string.Format(Language.ApiServerDetailsMessage, apiServerUrl, apiServerPassword);
+            string apiServerUrl = Properties.OptionsApiServerPage.Default.ApiServerUrl ?? string.Empty;
+            string apiServerUsername = Properties.OptionsApiServerPage.Default.ApiServerUsername ?? string.Empty;
+            string encryptedPassword = Properties.OptionsApiServerPage.Default.ApiServerPassword ?? string.Empty;
+            string apiServerPassword = cryptographyProvider.Decrypt(encryptedPassword, Runtime.EncryptionKey);
+
+            string message = string.Format(Language.ApiServerDetailsMessage, apiServerUrl, apiServerUsername, apiServerPassword);
 
             MessageBox.Show(this, message, Language.Upload, MessageBoxButtons.OK, MessageBoxIcon.Information);
         }


### PR DESCRIPTION
## Summary
- retrieve API server URL, username, and decrypted password from the API server options when invoking the upload dialog
- extend the localized API server details message to display the username between the URL and password values

## Testing
- dotnet build mRemoteNG.sln *(fails: `dotnet` command not found in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c91e380fb0832094e28581cbee54c3